### PR TITLE
[Docs feature] Add "Copy to clipboard" button on code samples

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -62,7 +62,8 @@ const siteConfig = {
   favicon: "img/favicon.png",
 
   stylesheets: [
-    "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700"
+    "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700",
+    "/css/code-block-buttons.css",
   ],
 
   /* Colors for website */
@@ -80,7 +81,11 @@ const siteConfig = {
   },
 
   // Add custom scripts here that would be placed in <script> tags.
-  scripts: ["https://buttons.github.io/buttons.js"],
+  scripts: [
+    "https://buttons.github.io/buttons.js",
+    "https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js",
+    "/js/code-block-buttons.js",
+  ],
 
   // On page navigation for the current documentation page.
   onPageNav: "separate",

--- a/website/static/css/code-block-buttons.css
+++ b/website/static/css/code-block-buttons.css
@@ -1,0 +1,39 @@
+/* "Copy" code block button */
+pre {
+  position: relative;
+}
+
+pre .btnIcon {
+  position: absolute;
+  top: 4px;
+  z-index: 2;
+  cursor: pointer;
+  border: 1px solid transparent;
+  padding: 0;
+  color: #fff;
+  background-color: transparent;
+  height: 30px;
+  transition: all 0.25s ease-out;
+}
+
+pre .btnIcon:hover {
+  text-decoration: none;
+}
+
+.btnIcon__body {
+  align-items: center;
+  display: flex;
+}
+
+.btnIcon svg {
+  fill: currentColor;
+  margin-right: 0.4em;
+}
+
+.btnIcon__label {
+  font-size: 11px;
+}
+
+.btnClipboard {
+  right: 10px;
+}

--- a/website/static/js/code-block-buttons.js
+++ b/website/static/js/code-block-buttons.js
@@ -1,0 +1,43 @@
+window.addEventListener("load", () => {
+  const button = (label, ariaLabel, icon, className) => {
+    const btn = document.createElement("button");
+    btn.classList.add("btnIcon", className);
+    btn.setAttribute("type", "button");
+    btn.setAttribute("aria-label", ariaLabel);
+    btn.innerHTML =
+      '<div class="btnIcon__body">' +
+      icon +
+      '<strong class="btnIcon__label">' +
+      label +
+      "</strong>" +
+      "</div>";
+    return btn;
+  };
+
+  const addButtons = (codeBlockSelector, btn) => {
+    document.querySelectorAll(codeBlockSelector).forEach((code) => {
+      code.parentNode.appendChild(btn.cloneNode(true));
+    });
+  };
+
+  const copyIcon =
+    '<svg width="12" height="12" viewBox="340 364 14 15" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M342 375.974h4v.998h-4v-.998zm5-5.987h-5v.998h5v-.998zm2 2.994v-1.995l-3 2.993 3 2.994v-1.996h5v-1.995h-5zm-4.5-.997H342v.998h2.5v-.997zm-2.5 2.993h2.5v-.998H342v.998zm9 .998h1v1.996c-.016.28-.11.514-.297.702-.187.187-.422.28-.703.296h-10c-.547 0-1-.452-1-.998v-10.976c0-.546.453-.998 1-.998h3c0-1.107.89-1.996 2-1.996 1.11 0 2 .89 2 1.996h3c.547 0 1 .452 1 .998v4.99h-1v-2.995h-10v8.98h10v-1.996zm-9-7.983h8c0-.544-.453-.996-1-.996h-1c-.547 0-1-.453-1-.998 0-.546-.453-.998-1-.998-.547 0-1 .452-1 .998 0 .545-.453.998-1 .998h-1c-.547 0-1 .452-1 .997z" fill-rule="evenodd"/></svg>';
+
+  addButtons(
+    ".hljs",
+    button("Copy", "Copy code to clipboard", copyIcon, "btnClipboard")
+  );
+
+  const clipboard = new ClipboardJS(".btnClipboard", {
+    target: function (trigger) {
+      return trigger.parentNode.querySelector("code");
+    },
+  });
+
+  clipboard.on("success", (event) => {
+    event.clearSelection();
+    const textEl = event.trigger.querySelector(".btnIcon__label");
+    textEl.textContent = "Copied";
+    setTimeout(() => (textEl.textContent = "Copy"), 2000);
+  });
+});


### PR DESCRIPTION
Hey! 👋 

I was going through the docs today and thought that maybe adding a "Copy to clipboard" button on the code samples could make it easier for people to go through the "Get started" tutorials! 🙂 
People can still manually copy and paste if they want but personally, I sometimes think I copied a whole code sample and actually I didn't so I thought a "Copy" button could be helpful.

Here's a quick demo:

![copy](https://user-images.githubusercontent.com/5985247/100611589-dc650280-3311-11eb-893b-7140a802274e.gif)

[Example in the deploy preview](https://deploy-preview-60--notion-js.netlify.app/docs/tutorials/your-first-web-app#-authentication)

I'm not super familiar with Docusaurus so I just followed the code sample in [this doc](https://gist.github.com/yangshun/55db997ed0f8f4e6527571fc3bee4675).

No worries at all if you think that's not a good idea! 🙂 