### PR TITLE
feat: generate new token when user requests one

### DIFF
--- a/src/api/https/getOAuthToken.ts
+++ b/src/api/https/getOAuthToken.ts
@@ -4,13 +4,26 @@ import { getFunctionsBaseURL } from "./utils";
 import { NotionOptions } from "../../types/options";
 import { OAuthQuery, OAuthQueryResult } from "../../types/oauth";
 
-export function getOAuthToken(
+export async function getOAuthToken(
   query: OAuthQuery,
   sdkOptions: NotionOptions
 ): Promise<OAuthQueryResult> {
   const baseUrl = getFunctionsBaseURL(sdkOptions);
 
+  // Get refresh token
+  const refreshResponse = await axios.post(
+    `${baseUrl}/getOAuthRefreshToken`,
+    query
+  );
+
+  const refreshToken = refreshResponse.data;
+
   return axios
-    .post(`${baseUrl}/getOAuthToken`, query)
-    .then((response) => response.data);
+    .post(`${baseUrl}/token`, {
+      grant_type: "refresh_token",
+      refresh_token: refreshToken.data,
+      client_id: query.clientId,
+      client_secret: query.clientSecret
+    })
+    .then((response) => JSON.parse(response.data)["access_token"]);
 }


### PR DESCRIPTION
Reworks the existing `getOAuthToken` method to generate a new token using a refresh token.