### PR TITLE
feat(sdk): add kinesis over Bluetooth transport

### DIFF
--- a/src/Neurosity.ts
+++ b/src/Neurosity.ts
@@ -1395,7 +1395,14 @@ export class Neurosity {
   }
 
   /**
-   * <StreamingModes wifi={true} />
+   * <StreamingModes wifi={true} bluetooth={true} />
+   *
+   * Observes kinesis classification events for the given label.
+   *
+   * When the active streaming transport is Wi-Fi, events are routed through
+   * the cloud (Firebase). When the active transport is Bluetooth, events are
+   * streamed directly from the device over the `kinesis` BLE characteristic,
+   * so clients can receive classifications without a cloud roundtrip.
    *
    * @param label Name of metric properties to filter by
    * @returns Observable of kinesis metric events
@@ -1413,10 +1420,14 @@ export class Neurosity {
       return throwError(() => OAuthError);
     }
 
-    return getCloudMetric(this._getCloudMetricDependencies(), {
-      metric,
-      labels: label ? [label] : [],
-      atomic: false
+    return this._withStreamingModeObservable({
+      wifi: () =>
+        getCloudMetric(this._getCloudMetricDependencies(), {
+          metric,
+          labels: label ? [label] : [],
+          atomic: false
+        }),
+      bluetooth: () => this.bluetoothClient.kinesis(label)
     });
   }
 

--- a/src/__tests__/BluetoothClient.kinesis.test.ts
+++ b/src/__tests__/BluetoothClient.kinesis.test.ts
@@ -1,0 +1,191 @@
+import { BehaviorSubject, Subject, Subscription, NEVER, of } from "rxjs";
+import { take, toArray } from "rxjs/operators";
+
+import { BluetoothClient } from "../api/bluetooth/BluetoothClient";
+import {
+  BLUETOOTH_CONNECTION,
+  TRANSPORT_TYPE
+} from "../api/bluetooth/types";
+import { Kinesis } from "../types/kinesis";
+import { DeviceInfo } from "../types/deviceInfo";
+
+/**
+ * Builds a minimal fake BluetoothTransport that satisfies the surface of
+ * `BluetoothClient` used by `kinesis()`. The real WebBluetoothTransport is
+ * deliberately not instantiated here because its `_onDisconnected` wiring
+ * requires a live GATT device.
+ */
+function createFakeTransport(kinesisFeed$: Subject<Kinesis>) {
+  const subscribeToCharacteristic = jest
+    .fn()
+    .mockImplementation(({ characteristicName }) => {
+      if (characteristicName === "kinesis") {
+        return kinesisFeed$.asObservable();
+      }
+      return NEVER;
+    });
+
+  return {
+    type: TRANSPORT_TYPE.WEB,
+    addLog: jest.fn(),
+    logs$: new Subject<string>(),
+    connection$: new BehaviorSubject<BLUETOOTH_CONNECTION>(
+      BLUETOOTH_CONNECTION.CONNECTED
+    ),
+    onDisconnected$: NEVER,
+    connection: () => of(BLUETOOTH_CONNECTION.CONNECTED),
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    readCharacteristic: jest.fn(),
+    writeCharacteristic: jest.fn(),
+    dispatchAction: jest.fn(),
+    subscribeToCharacteristic,
+    _autoConnect: () => NEVER,
+    _autoToggleActionNotifications: () => NEVER,
+    enableAutoConnect: jest.fn()
+  } as any;
+}
+
+describe("BluetoothClient.kinesis()", () => {
+  let client: BluetoothClient;
+  let kinesisFeed$: Subject<Kinesis>;
+  let transport: any;
+
+  beforeEach(() => {
+    kinesisFeed$ = new Subject<Kinesis>();
+    transport = createFakeTransport(kinesisFeed$);
+
+    const selectedDevice$ = new BehaviorSubject<DeviceInfo | null>({
+      deviceId: "test-device-id",
+      deviceNickname: "Test",
+      channelNames: ["CP3", "C3", "F5", "PO3", "PO4", "F6", "C4", "CP4"],
+      channels: 8,
+      samplingRate: 256,
+      manufacturer: "Neurosity",
+      model: "Crown",
+      modelName: "Crown",
+      modelVersion: "3",
+      apiVersion: "1.0.0",
+      osVersion: "16.0.0",
+      emulator: false
+    });
+    const osHasBluetoothSupport$ = new BehaviorSubject<boolean>(true);
+
+    client = new BluetoothClient({
+      transport,
+      selectedDevice$,
+      osHasBluetoothSupport$,
+      createBluetoothToken: undefined as any
+    });
+
+    // The constructor wires auto-authentication only when a
+    // createBluetoothToken function is provided, so the authenticated state
+    // must be pushed directly for the metric streams to become active.
+    client.isAuthenticated$.next(true);
+  });
+
+  it("subscribes to the `kinesis` BLE characteristic on first use", (done) => {
+    const sub: Subscription = client
+      .kinesis("leftHandPinch")
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          expect(transport.subscribeToCharacteristic).toHaveBeenCalledWith(
+            expect.objectContaining({ characteristicName: "kinesis" })
+          );
+          sub.unsubscribe();
+          done();
+        },
+        error: done
+      });
+
+    setImmediate(() =>
+      kinesisFeed$.next({
+        metric: "kinesis",
+        label: "leftHandPinch",
+        probability: 0.7,
+        timestamp: 1
+      })
+    );
+  });
+
+  it("filters events by label when provided", (done) => {
+    const sub: Subscription = client
+      .kinesis("leftHandPinch")
+      .pipe(take(2), toArray())
+      .subscribe({
+        next: (received) => {
+          expect(received.map((k) => k.probability)).toEqual([0.4, 0.9]);
+          sub.unsubscribe();
+          done();
+        },
+        error: done
+      });
+
+    setImmediate(() => {
+      kinesisFeed$.next({
+        metric: "kinesis",
+        label: "rightHandPinch",
+        probability: 0.1,
+        timestamp: 1
+      });
+      kinesisFeed$.next({
+        metric: "kinesis",
+        label: "leftHandPinch",
+        probability: 0.4,
+        timestamp: 2
+      });
+      kinesisFeed$.next({
+        metric: "kinesis",
+        label: "rightHandPinch",
+        probability: 0.55,
+        timestamp: 3
+      });
+      kinesisFeed$.next({
+        metric: "kinesis",
+        label: "leftHandPinch",
+        probability: 0.9,
+        timestamp: 4
+      });
+    });
+  });
+
+  it("emits every event when no label is provided", (done) => {
+    const sub: Subscription = client
+      .kinesis()
+      .pipe(take(3), toArray())
+      .subscribe({
+        next: (received) => {
+          expect(received.map((k) => k.label)).toEqual([
+            "leftHandPinch",
+            "rightHandPinch",
+            "tongue"
+          ]);
+          sub.unsubscribe();
+          done();
+        },
+        error: done
+      });
+
+    setImmediate(() => {
+      kinesisFeed$.next({
+        metric: "kinesis",
+        label: "leftHandPinch",
+        probability: 0.1,
+        timestamp: 1
+      });
+      kinesisFeed$.next({
+        metric: "kinesis",
+        label: "rightHandPinch",
+        probability: 0.2,
+        timestamp: 2
+      });
+      kinesisFeed$.next({
+        metric: "kinesis",
+        label: "tongue",
+        probability: 0.3,
+        timestamp: 3
+      });
+    });
+  });
+});

--- a/src/__tests__/kinesis-bluetooth.test.ts
+++ b/src/__tests__/kinesis-bluetooth.test.ts
@@ -1,0 +1,229 @@
+import { Neurosity } from "../Neurosity";
+import { BehaviorSubject, Subject, Subscription } from "rxjs";
+import { filter, take, toArray } from "rxjs/operators";
+import { DeviceInfo } from "../types/deviceInfo";
+import { STATUS } from "../types/status";
+import { DeviceStatus } from "../types/status";
+import { Kinesis } from "../types/kinesis";
+import { STREAMING_TYPE, STREAMING_MODE } from "../types/streaming";
+
+// Mock CloudClient so the SDK constructs without hitting Firebase. The cloud
+// path for kinesis is not exercised in this file; we exercise only the BLE
+// path by forcing the active streaming mode to BLUETOOTH below.
+jest.mock("../api", () => {
+  const originalModule = jest.requireActual("../api");
+
+  class MockCloudClient {
+    public user = null;
+    public userClaims = { scopes: ["kinesis"] };
+    protected options: any;
+    public subscriptionManager = {
+      add: jest.fn(),
+      remove: jest.fn(),
+      removeAll: jest.fn()
+    };
+
+    private _selectedDevice = new BehaviorSubject<DeviceInfo | null>({
+      deviceId: "test-device-id",
+      deviceNickname: "Test Device",
+      channelNames: ["CP3", "C3", "F5", "PO3", "PO4", "F6", "C4", "CP4"],
+      channels: 8,
+      samplingRate: 256,
+      manufacturer: "Neurosity",
+      model: "Crown",
+      modelName: "Crown",
+      modelVersion: "3",
+      apiVersion: "1.0.0",
+      osVersion: "16.0.0",
+      emulator: false
+    });
+
+    constructor(options: any) {
+      this.options = options;
+    }
+
+    login = jest.fn().mockResolvedValue({});
+    logout = jest.fn().mockResolvedValue({});
+    getInfo = jest.fn().mockResolvedValue(this._selectedDevice.value);
+    selectDevice = jest
+      .fn()
+      .mockImplementation(async () => this._selectedDevice.value);
+    didSelectDevice = jest.fn().mockResolvedValue(true);
+    onDeviceChange = jest.fn().mockReturnValue(this._selectedDevice);
+    osVersion = jest.fn().mockReturnValue(new BehaviorSubject("16.0.0"));
+    status = jest.fn().mockReturnValue(
+      new BehaviorSubject<DeviceStatus>({
+        state: STATUS.ONLINE,
+        charging: false,
+        battery: 100,
+        sleepMode: false,
+        sleepModeReason: null,
+        lastHeartbeat: Date.now(),
+        ssid: "test-network"
+      })
+    );
+    metrics = {
+      subscribe: jest.fn(),
+      on: jest.fn().mockImplementation(() => () => {}),
+      unsubscribe: jest.fn()
+    };
+  }
+
+  return {
+    ...originalModule,
+    CloudClient: jest
+      .fn()
+      .mockImplementation((options) => new MockCloudClient(options))
+  };
+});
+
+describe("Kinesis over Bluetooth", () => {
+  let neurosity: Neurosity;
+  let kinesis$: Subject<Kinesis>;
+  const testDeviceId = "test-device-id";
+
+  beforeEach(() => {
+    neurosity = new Neurosity({
+      deviceId: testDeviceId,
+      emulator: true
+    });
+
+    // Stream used by the fake bluetoothClient as the BLE `kinesis`
+    // characteristic feed.
+    kinesis$ = new Subject<Kinesis>();
+
+    // Replace internals so _withStreamingModeObservable picks the BLE branch.
+    const anyNeurosity = neurosity as any;
+    anyNeurosity.bluetoothClient = {
+      kinesis: jest.fn().mockImplementation((label?: string) => {
+        if (!label) {
+          return kinesis$.asObservable();
+        }
+        return kinesis$
+          .asObservable()
+          .pipe(filter((event: Kinesis) => event?.label === label));
+      })
+    };
+
+    // Force the active streaming mode to BLUETOOTH so
+    // _withStreamingModeObservable selects the bluetooth branch.
+    anyNeurosity.streamingState = jest.fn().mockReturnValue(
+      new BehaviorSubject({
+        connected: true,
+        activeMode: STREAMING_TYPE.BLUETOOTH,
+        streamingMode: STREAMING_MODE.BLUETOOTH_WITH_WIFI_FALLBACK
+      })
+    );
+  });
+
+  it("emits kinesis events received over the BLE transport", (done) => {
+    const expected: Kinesis = {
+      metric: "kinesis",
+      label: "leftHandPinch",
+      probability: 0.83,
+      timestamp: Date.now()
+    };
+
+    neurosity
+      .kinesis("leftHandPinch")
+      .pipe(take(1))
+      .subscribe({
+        next: (kinesis) => {
+          expect(kinesis).toEqual(expected);
+          expect((neurosity as any).bluetoothClient.kinesis).toHaveBeenCalledWith(
+            "leftHandPinch"
+          );
+          done();
+        },
+        error: done
+      });
+
+    // Emit after subscription is set up to avoid missing the Subject event.
+    setImmediate(() => kinesis$.next(expected));
+  });
+
+  it("filters to the requested label on the BLE path", (done) => {
+    const events: Kinesis[] = [
+      {
+        metric: "kinesis",
+        label: "rightHandPinch",
+        probability: 0.11,
+        timestamp: 1
+      },
+      {
+        metric: "kinesis",
+        label: "leftHandPinch",
+        probability: 0.42,
+        timestamp: 2
+      },
+      {
+        metric: "kinesis",
+        label: "rightHandPinch",
+        probability: 0.77,
+        timestamp: 3
+      },
+      {
+        metric: "kinesis",
+        label: "leftHandPinch",
+        probability: 0.95,
+        timestamp: 4
+      }
+    ];
+
+    const sub: Subscription = neurosity
+      .kinesis("leftHandPinch")
+      .pipe(take(2), toArray())
+      .subscribe({
+        next: (received) => {
+          expect(received.map((k) => k.probability)).toEqual([0.42, 0.95]);
+          expect(received.every((k) => k.label === "leftHandPinch")).toBe(true);
+          sub.unsubscribe();
+          done();
+        },
+        error: done
+      });
+
+    setImmediate(() => {
+      for (const event of events) {
+        kinesis$.next(event);
+      }
+    });
+  });
+
+  it("emits all kinesis events when no label is provided", (done) => {
+    const events: Kinesis[] = [
+      {
+        metric: "kinesis",
+        label: "leftHandPinch",
+        probability: 0.2,
+        timestamp: 1
+      },
+      {
+        metric: "kinesis",
+        label: "rightHandPinch",
+        probability: 0.5,
+        timestamp: 2
+      }
+    ];
+
+    neurosity
+      .kinesis(undefined as unknown as string)
+      .pipe(take(2), toArray())
+      .subscribe({
+        next: (received) => {
+          expect(received.map((k) => k.label)).toEqual([
+            "leftHandPinch",
+            "rightHandPinch"
+          ]);
+          done();
+        },
+        error: done
+      });
+
+    setImmediate(() => {
+      for (const event of events) {
+        kinesis$.next(event);
+      }
+    });
+  });
+});

--- a/src/api/bluetooth/BluetoothClient.ts
+++ b/src/api/bluetooth/BluetoothClient.ts
@@ -1,6 +1,12 @@
 import { defer, Observable, timer } from "rxjs";
 import { ReplaySubject, firstValueFrom, EMPTY } from "rxjs";
-import { switchMap, share, tap, distinctUntilChanged } from "rxjs/operators";
+import {
+  switchMap,
+  share,
+  tap,
+  distinctUntilChanged,
+  filter
+} from "rxjs/operators";
 
 import { WebBluetoothTransport } from "./web/WebBluetoothTransport";
 import { ReactNativeTransport } from "./react-native/ReactNativeTransport";
@@ -8,6 +14,7 @@ import { binaryBufferToEpoch } from "./utils/binaryBufferToEpoch";
 import { DeviceInfo } from "../../types/deviceInfo";
 import { Action } from "../../types/actions";
 import { Epoch } from "../../types/epoch";
+import { Kinesis } from "../../types/kinesis";
 import { BLUETOOTH_CONNECTION } from "./types";
 import { DeviceNicknameOrPeripheral } from "./BluetoothTransport";
 import { Peripheral } from "./react-native/types/BleManagerTypes";
@@ -36,6 +43,7 @@ export class BluetoothClient {
 
   _focus$: Observable<any>;
   _calm$: Observable<any>;
+  _kinesis$: Observable<any>;
   _accelerometer$: Observable<any>;
   _brainwavesRaw$: Observable<any>;
   _brainwavesRawUnfiltered$: Observable<any>;
@@ -110,6 +118,7 @@ export class BluetoothClient {
     // Multicast metrics (share)
     this._focus$ = this._subscribeWhileAuthenticated("focus");
     this._calm$ = this._subscribeWhileAuthenticated("calm");
+    this._kinesis$ = this._subscribeWhileAuthenticated("kinesis");
     this._accelerometer$ = this._subscribeWhileAuthenticated("accelerometer");
     this._brainwavesRaw$ = this._subscribeWhileAuthenticated(
       "raw",
@@ -302,6 +311,32 @@ export class BluetoothClient {
 
   calm() {
     return this._calm$;
+  }
+
+  /**
+   * Observes kinesis classification events streamed over BLE.
+   *
+   * The firmware emits JSON events of shape
+   * `{ metric: "kinesis", label: string, probability: number, timestamp: number }`
+   * on the `kinesis` characteristic. When a `label` is provided, the stream is
+   * filtered to only emit events matching that label, mirroring the cloud
+   * `kinesis(label)` semantics.
+   *
+   * @param label Optional kinesis label to filter by (e.g. `"leftHandPinch"`).
+   *              When omitted, all kinesis events are emitted.
+   * @returns Observable of `Kinesis` events.
+   */
+  kinesis(label?: string): Observable<Kinesis> {
+    if (!label) {
+      return this._kinesis$;
+    }
+
+    return this._kinesis$.pipe(
+      filter(
+        (event: Kinesis) =>
+          !!event && typeof event.label === "string" && event.label === label
+      )
+    );
   }
 
   accelerometer() {


### PR DESCRIPTION
## Summary

Route `neurosity.kinesis(label)` through the BLE transport whenever the active
streaming mode is Bluetooth, so offline / LAN-only clients get the same
classification stream as cloud-connected clients. The change mirrors the
dual-transport pattern used by `focus`, `calm`, and `accelerometer` — no
refactoring of the transport-switching helper was needed.

### Design choice

- **`BluetoothClient`** gains a shared `_kinesis$` multicast on the
  `kinesis` BLE characteristic and a public `kinesis(label?)` method that
  applies cloud-equivalent label filtering client-side.
- **`Neurosity.kinesis()`** now calls `_withStreamingModeObservable({ wifi,
  bluetooth })` instead of hard-coding the cloud path. When `activeMode` is
  `BLUETOOTH`, the stream comes straight off the BLE characteristic with no
  cloud roundtrip.
- Filtering is done client-side (matching how the cloud path accepts a single
  label), which keeps the firmware payload simple: `{ metric, label,
  probability, timestamp }` per classification event.
- No transport-layer refactors; no new public configuration surface.

## Unknowns / needs firmware + IPK verification

The client routing is in place, but `@neurosity/ipk@2.13.0` does **not** yet
ship a `kinesis` entry in `BLUETOOTH_CHARACTERISTICS`. Until the firmware
exposes the characteristic and the IPK registers its UUID:

- `WebBluetoothTransport.characteristicsByName["kinesis"]` will be `undefined`
  at runtime, so the subscription stays idle (no events). This is the same
  graceful-no-op behaviour every other feature had before its firmware shipped.
- No SDK changes are required once the IPK upgrade lands — the subscription
  will start emitting automatically.

Follow-ups (**not** in this PR):

- [ ] Firmware: implement the `kinesis` BLE characteristic (notify) that
  emits the same JSON events the cloud emits.
- [ ] `@neurosity/ipk`: add a `kinesis` UUID to `BLUETOOTH_CHARACTERISTICS`.
- [ ] Once both land, bump `@neurosity/ipk` in this repo to pick up the UUID.

## Test plan

- [x] `npm run build` — succeeds
- [x] `npm test` — 18 suites / 138 tests passing (6 pre-existing skips)
- [x] `npm run lint` — no new warnings introduced
- [x] `npm audit` — no new vulnerabilities introduced (pre-existing
  `follow-redirects` + `protobufjs` advisories already on `master`)
- [x] Unit test covers `BluetoothClient.kinesis()` subscribing to the
  `kinesis` characteristic, filtering by label, and emitting all events
  when no label is provided
- [x] Unit test covers `Neurosity.kinesis()` selecting the BLE branch when
  `activeMode === BLUETOOTH` and propagating label filtering

### Manual verification (requires firmware + IPK follow-ups above)

- [ ] Connect a Crown over BLE with streaming mode
  `BLUETOOTH_WITH_WIFI_FALLBACK`, call `neurosity.kinesis("leftHandPinch")`,
  confirm events flow without WiFi.
- [ ] Disconnect WiFi mid-stream, confirm the observable keeps emitting via
  BLE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)