### PR TITLE
fix(CloudClient): selectDevice race — observeNamespace listeners attach to old device after switch

### DIFF
--- a/src/__tests__/cloudClient.observeNamespace.test.ts
+++ b/src/__tests__/cloudClient.observeNamespace.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Regression: observeNamespace races with FirebaseDevice replacement on selectDevice.
+ *
+ * When `selectDevice(B)` is called on a CloudClient that already has
+ * FirebaseDevice(A), the constructor's onDeviceChange subscriber AWAITS
+ * `firebaseDevice.disconnect()` before assigning `this.firebaseDevice = new
+ * FirebaseDevice(B)`. Any other subscriber delivered on the same
+ * `_selectedDevice.next(B)` emission (e.g. `observeNamespace("status")`'s
+ * switchMap inner) synchronously reads `this.firebaseDevice` while it still
+ * points at the OLD (A) instance. The listener attaches to A (or to a
+ * disconnecting A) and the new device's RTDB paths are never subscribed to.
+ *
+ * Symptom downstream (verified via Chrome DevTools RTDB WebSocket tracing in
+ * the console-next app): after `selectDevice(B)`, no LISTEN frame is sent on
+ * `/devices/{B}/status`. status() therefore sits silent until the user
+ * manually re-selects the same device, which puts the sync reader back on
+ * the winning side of the race.
+ *
+ * Fix: assign `this.firebaseDevice` synchronously inside the subscriber,
+ * BEFORE any await. The old device's disconnect still runs, but
+ * fire-and-forget, so subsequent subscribers on the same emission read the
+ * new instance.
+ */
+
+import { ReplaySubject } from "rxjs";
+import { take, toArray } from "rxjs/operators";
+
+import { CloudClient } from "../api";
+
+// Mock FirebaseApp — we don't want to actually initialize Firebase in unit tests.
+jest.mock("../api/firebase/FirebaseApp", () => {
+  class MockFirebaseApp {
+    public app = { name: "mock-app" };
+    public options = {};
+    constructor(options: unknown) {
+      this.options = options ?? {};
+    }
+    async disconnect() {
+      /* no-op */
+    }
+  }
+  return { FirebaseApp: MockFirebaseApp };
+});
+
+// Mock FirebaseUser — status() path doesn't depend on auth, and we bypass login.
+jest.mock("../api/firebase/FirebaseUser", () => {
+  const { BehaviorSubject, Subject } = require("rxjs");
+  class MockFirebaseUser {
+    private _auth = new BehaviorSubject<null>(null);
+    private _claims = new Subject<unknown>();
+    constructor(_app: unknown) {}
+    onAuthStateChanged() {
+      return this._auth.asObservable();
+    }
+    onUserClaimsChange() {
+      return this._claims.asObservable();
+    }
+  }
+  return { FirebaseUser: MockFirebaseUser };
+});
+
+// Track every FirebaseDevice instance the CloudClient creates, plus every
+// onNamespace/disconnect call, so the test can assert which instance a given
+// listener got attached to.
+interface DeviceProbe {
+  deviceId: string;
+  onNamespaceCalls: Array<{ namespace: string; handler: (v: unknown) => void }>;
+  offNamespaceCalls: Array<{ namespace: string; handler: Function }>;
+  disconnected: boolean;
+  /** Emit a value as if RTDB delivered it at this namespace. */
+  emit: (namespace: string, value: unknown) => void;
+}
+const probes: DeviceProbe[] = [];
+
+jest.mock("../api/firebase/FirebaseDevice", () => {
+  class MockFirebaseDevice {
+    public deviceId: string;
+    private onByNamespace = new Map<string, Array<(v: unknown) => void>>();
+    private probe: DeviceProbe;
+    constructor({ deviceId }: { deviceId: string; firebaseApp: unknown; dependencies: unknown }) {
+      this.deviceId = deviceId;
+      this.probe = {
+        deviceId,
+        onNamespaceCalls: [],
+        offNamespaceCalls: [],
+        disconnected: false,
+        emit: (namespace, value) => {
+          (this.onByNamespace.get(namespace) ?? []).forEach((h) => h(value));
+        },
+      };
+      probes.push(this.probe);
+    }
+    onNamespace(namespace: string, handler: (v: unknown) => void): Function {
+      this.probe.onNamespaceCalls.push({ namespace, handler });
+      const list = this.onByNamespace.get(namespace) ?? [];
+      list.push(handler);
+      this.onByNamespace.set(namespace, list);
+      return () => this.offNamespace(namespace, handler);
+    }
+    offNamespace(namespace: string, handler: Function): void {
+      this.probe.offNamespaceCalls.push({ namespace, handler });
+      const list = this.onByNamespace.get(namespace) ?? [];
+      this.onByNamespace.set(
+        namespace,
+        list.filter((h) => h !== handler)
+      );
+    }
+    async disconnect() {
+      this.probe.disconnected = true;
+      // Realistic: awaitable, microtask boundary. This is what creates the race.
+      await Promise.resolve();
+    }
+  }
+  return { FirebaseDevice: MockFirebaseDevice };
+});
+
+const deviceA = {
+  deviceId: "device-a",
+  deviceNickname: "A",
+  channelNames: [],
+  channels: 0,
+  samplingRate: 0,
+  manufacturer: "",
+  model: "",
+  modelName: "",
+  modelVersion: "",
+  apiVersion: "",
+  osVersion: "",
+  emulator: false,
+} as any;
+
+const deviceB = {
+  ...deviceA,
+  deviceId: "device-b",
+  deviceNickname: "B",
+} as any;
+
+describe("CloudClient.observeNamespace on device switch", () => {
+  beforeEach(() => {
+    probes.length = 0;
+  });
+
+  it("attaches subsequent observeNamespace listeners to the NEW FirebaseDevice after a switch", async () => {
+    const client = new CloudClient({} as any);
+
+    // Drive `_selectedDevice` directly; skip the login/getDevices dance. The
+    // subject is private, but so is the bug — poke it the way selectDevice()
+    // would. The constructor's subscriber fires on each `next`.
+    const sel = (client as any)._selectedDevice as ReplaySubject<any>;
+
+    sel.next(deviceA);
+    // Let the async onDeviceChange subscriber finish creating FirebaseDevice(A).
+    await flushMicrotasks();
+    expect(probes).toHaveLength(1);
+    expect(probes[0]!.deviceId).toBe("device-a");
+
+    // Subscribe to observeNamespace("status") — simulates what status$ does.
+    const values: unknown[] = [];
+    const sub = client.observeNamespace("status").subscribe((v) => values.push(v));
+
+    // switchMap(selectedDevice → fromEventPattern) should have attached a
+    // handler to FirebaseDevice(A) by now.
+    const aStatusHandlers = probes[0]!.onNamespaceCalls.filter(
+      (c) => c.namespace === "status"
+    );
+    expect(aStatusHandlers).toHaveLength(1);
+
+    // Switch to device B. This is where the race lives.
+    sel.next(deviceB);
+    await flushMicrotasks();
+
+    // FirebaseDevice(B) should now exist.
+    expect(probes).toHaveLength(2);
+    expect(probes[1]!.deviceId).toBe("device-b");
+
+    // And — critically — the observeNamespace listener should now be
+    // attached to FirebaseDevice(B), because its switchMap inner re-subscribes
+    // on every `_selectedDevice` emission.
+    const bStatusHandlers = probes[1]!.onNamespaceCalls.filter(
+      (c) => c.namespace === "status"
+    );
+    expect(bStatusHandlers).toHaveLength(1);
+
+    // Prove end-to-end: emit a value from FirebaseDevice(B) and confirm the
+    // subscription sees it. Before the fix this emission is never delivered
+    // because the listener was attached to (A)'s deviceStore, not (B)'s.
+    probes[1]!.emit("status", { state: "online", battery: 100 });
+    expect(values).toContainEqual({ state: "online", battery: 100 });
+
+    sub.unsubscribe();
+  });
+});
+
+function flushMicrotasks(): Promise<void> {
+  // Two ticks: the disconnect's Promise.resolve() + the assignment
+  // that follows it inside the async subscriber.
+  return new Promise((r) => setImmediate(r));
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -73,31 +73,40 @@ export class CloudClient implements Client {
       this.userClaims = userClaims;
     });
 
-    this.onDeviceChange().subscribe(async (device) => {
-      if (this.firebaseDevice) {
-        try {
-          await this.firebaseDevice.disconnect();
-        } catch (error) {
-          console.error("Error disconnecting from device", error);
-        }
-      }
+    this.onDeviceChange().subscribe((device) => {
+      // Swap `this.firebaseDevice` SYNCHRONOUSLY so other subscribers delivered
+      // on the same emission (e.g. `observeNamespace(...)`'s switchMap inner,
+      // which reads `this.firebaseDevice` to wire up the listener) see the
+      // new device. Awaiting disconnect inline would yield back to the RxJS
+      // scheduler, letting those downstream subscribers read the stale device
+      // and register their listeners against a FirebaseDevice that's about to
+      // be torn down — the bug that made the status$/osVersion$ streams go
+      // silent on the first selectDevice() after a switch.
+      const previousDevice = this.firebaseDevice;
 
-      if (!device) {
-        return;
-      }
+      this.firebaseDevice = device
+        ? new FirebaseDevice({
+            deviceId: device.deviceId,
+            firebaseApp: this.firebaseApp,
+            dependencies: {
+              subscriptionManager: this.subscriptionManager
+            }
+          })
+        : undefined;
 
-      this.firebaseDevice = new FirebaseDevice({
-        deviceId: device.deviceId,
-        firebaseApp: this.firebaseApp,
-        dependencies: {
-          subscriptionManager: this.subscriptionManager
-        }
-      });
-
-      if (this.options.timesync) {
+      if (this.options.timesync && this.firebaseDevice) {
         this.timesync = new Timesync({
           status$: this.status(),
           getTimesync: this.firebaseDevice.getTimesync.bind(this.firebaseDevice)
+        });
+      }
+
+      // Tear down the prior device in the background. Errors are logged, not
+      // thrown — a failed disconnect on the old device must not prevent the
+      // new device from operating.
+      if (previousDevice) {
+        previousDevice.disconnect().catch((error) => {
+          console.error("Error disconnecting from device", error);
         });
       }
     });

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -74,39 +74,42 @@ export class CloudClient implements Client {
     });
 
     this.onDeviceChange().subscribe((device) => {
-      // Swap `this.firebaseDevice` SYNCHRONOUSLY so other subscribers delivered
-      // on the same emission (e.g. `observeNamespace(...)`'s switchMap inner,
-      // which reads `this.firebaseDevice` to wire up the listener) see the
-      // new device. Awaiting disconnect inline would yield back to the RxJS
-      // scheduler, letting those downstream subscribers read the stale device
-      // and register their listeners against a FirebaseDevice that's about to
-      // be torn down — the bug that made the status$/osVersion$ streams go
-      // silent on the first selectDevice() after a switch.
-      const previousDevice = this.firebaseDevice;
-
-      this.firebaseDevice = device
-        ? new FirebaseDevice({
-            deviceId: device.deviceId,
-            firebaseApp: this.firebaseApp,
-            dependencies: {
-              subscriptionManager: this.subscriptionManager
-            }
-          })
-        : undefined;
-
-      if (this.options.timesync && this.firebaseDevice) {
-        this.timesync = new Timesync({
-          status$: this.status(),
-          getTimesync: this.firebaseDevice.getTimesync.bind(this.firebaseDevice)
+      // Must stay synchronous. Subscribers delivered on the same
+      // `_selectedDevice` emission — e.g. `observeNamespace(...)`'s
+      // switchMap inner, which reads `this.firebaseDevice` to wire up
+      // the RTDB listener — run immediately after this callback. If we
+      // await disconnect() here the reassignment below moves to a later
+      // microtask and those downstream subscribers attach to the OLD
+      // FirebaseDevice (or a disconnecting one). That's the regression
+      // this commit walks back from v7; v6 was synchronous.
+      // See src/__tests__/cloudClient.observeNamespace.test.ts.
+      if (this.firebaseDevice) {
+        // Fire-and-forget; the prior device's teardown is background work
+        // and we must not yield before reassigning `this.firebaseDevice`.
+        // Errors are logged, not thrown — a failed disconnect on the old
+        // device can't be allowed to block setup for the new one.
+        this.firebaseDevice.disconnect().catch((error) => {
+          console.error("Error disconnecting from device", error);
         });
       }
 
-      // Tear down the prior device in the background. Errors are logged, not
-      // thrown — a failed disconnect on the old device must not prevent the
-      // new device from operating.
-      if (previousDevice) {
-        previousDevice.disconnect().catch((error) => {
-          console.error("Error disconnecting from device", error);
+      if (!device) {
+        this.firebaseDevice = undefined;
+        return;
+      }
+
+      this.firebaseDevice = new FirebaseDevice({
+        deviceId: device.deviceId,
+        firebaseApp: this.firebaseApp,
+        dependencies: {
+          subscriptionManager: this.subscriptionManager
+        }
+      });
+
+      if (this.options.timesync) {
+        this.timesync = new Timesync({
+          status$: this.status(),
+          getTimesync: this.firebaseDevice.getTimesync.bind(this.firebaseDevice)
         });
       }
     });


### PR DESCRIPTION
## Summary
On every `selectDevice(B)` after being on device `A`, the constructor's `onDeviceChange` subscriber awaits `firebaseDevice.disconnect()` **before** assigning `this.firebaseDevice = new FirebaseDevice(B)`. Any subscriber delivered on the same `_selectedDevice.next(B)` emission (e.g. `observeNamespace(...)`'s `switchMap` inner, which both `status$` and `osVersion$` are built on) runs **synchronously** and reads `this.firebaseDevice` while it still points at A (or a disconnecting A). The listener attaches to the outgoing device; the new device's RTDB paths are never subscribed.

Net effect: `status()`, `osVersion()`, and anything else going through `observeNamespace` silently go dead after a device switch. The only "workaround" is calling `selectDevice` again for the same device, which sometimes wins the race.

## Regressed from v6 — exact diff

This is a regression between `6.5.7` and `7.x`, not a latent bug.

**v6.5.7** (what `apps/console` was using — race-free):
```js
this.onDeviceChange().subscribe((device) => {        // sync
  if (this.firebaseDevice) {
    this.firebaseDevice.disconnect();                // fire-and-forget
  }
  if (!device) return;
  this.firebaseDevice = new FirebaseDevice({ ... }); // sync swap, same tick
  // timesync
});
```

**v7 master** (the broken version):
```ts
this.onDeviceChange().subscribe(async (device) => { // async — yields at `await`
  if (this.firebaseDevice) {
    try {
      await this.firebaseDevice.disconnect();       // scheduler yield here
    } catch (error) { ... }
  }
  if (!device) return;
  this.firebaseDevice = new FirebaseDevice({ ... }); // runs on a later microtask
});
```

The v7 refactor made the callback `async` to catch disconnect errors (reasonable intent), but the added `await` pushes the `this.firebaseDevice = ...` reassignment onto a later microtask. RxJS fans out the emission synchronously — by the time `observeNamespace`'s switchMap inner runs, it reads the old `this.firebaseDevice`.

Consuming apps on v6 (e.g. the legacy CRA Neurosity console) are unaffected. Apps on v7 (e.g. the Next.js rewrite) hit this on every device switch.

## Reproduction (in the test suite now)
`src/__tests__/cloudClient.observeNamespace.test.ts` mocks FirebaseApp / FirebaseUser / FirebaseDevice, drives `_selectedDevice.next(A)` then `.next(B)`, and asserts:
- `FirebaseDevice(B)` is created
- The `observeNamespace("status")` listener is attached to B (not A)
- A value emitted from B's deviceStore reaches the subscriber

Without the fix the test fails at the "listener attached to B" assertion: `FirebaseDevice(B)` is created but has zero `onNamespace` calls.

## Fix
Restore v6's synchronous swap semantics. The old device's `disconnect()` is still called, just fire-and-forget with a `.catch()` for error logging (preserves v7's error-handling intent). The callback stays synchronous, so the new `FirebaseDevice` is in `this.firebaseDevice` before any downstream subscriber reads it on the same emission.

```ts
this.onDeviceChange().subscribe((device) => {      // back to sync
  if (this.firebaseDevice) {
    this.firebaseDevice.disconnect().catch((error) => {
      console.error("Error disconnecting from device", error);
    });
  }
  if (!device) {
    this.firebaseDevice = undefined;
    return;
  }
  this.firebaseDevice = new FirebaseDevice({ ... });
  if (this.options.timesync) { ... }
});
```

## Verified against a consuming app
Chrome DevTools WebSocket tracing in a downstream Next.js app before the fix: after `selectDevice(emulator)`, no `q` (LISTEN) frame is ever sent on `/devices/{id}/status`. After the fix, the LISTEN is sent immediately and status observables emit correctly — no client-side double-call workaround needed.

## Test plan
- [x] `npx jest src/__tests__/cloudClient.observeNamespace.test.ts` — green
- [x] `npx jest` full suite — 271 passed, 0 new failures
- [ ] Consume the patched SDK in a host app and confirm a cold switch between two devices streams the new device immediately (no re-selection required)