### PR TITLE
chore: release v7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v7.2.0
+
+- FIX: `selectDevice()` race — `observeNamespace(...)` subscribers (including `status()` and `osVersion()`) attached their RTDB listeners to the outgoing `FirebaseDevice` on every device switch. The v7 refactor had made the `onDeviceChange` subscriber async and awaited `disconnect()` before assigning `this.firebaseDevice = new FirebaseDevice(...)` — so subscribers delivered on the same emission read the stale device. Restores v6's synchronous swap; disconnect is now fire-and-forget with error logging.
+
 # v7.1.0
 
 - FEAT: Added `signalQualityV2()` method with normalized 0-1 scores per channel and overall score

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neurosity/sdk",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neurosity/sdk",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
         "@neurosity/ipk": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neurosity/sdk",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Neurosity SDK",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Cuts v7.2.0 for the `selectDevice()` race fix merged in #135 (commits `76773d1`, `e2d2ed8`).

- `package.json` + `package-lock.json` → 7.2.0
- `CHANGELOG.md` entry summarizing the fix (reviewer-audit-friendly phrasing matches the PR body from #135)

## Version choice
Strict semver says this is a patch (7.1.1) — internal bug fix, no API surface change. Using minor (7.2.0) to make the fix more visible to downstream consumers, since it materially changes runtime behavior (status/osVersion streams now actually fire after a switch) and host apps on 7.1.x may have written workarounds they'll want to remove.

## After merge
- Tag `v7.2.0` on master
- `npm publish`