### PR TITLE
fix: isMaybeWebWorkerContext actually detects worker context (+ kill rollup warning)

### DIFF
--- a/src/__tests__/isMaybeWebWorkerContext.test.ts
+++ b/src/__tests__/isMaybeWebWorkerContext.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression: `isMaybeWebWorkerContext()` was reading top-level `this` to get
+ * a reference to the global scope. In ES modules (which rollup emits) top-
+ * level `this` is `undefined` per spec — rollup even warns about the rewrite
+ * on every build. So the helper returned a falsy result unconditionally,
+ * regardless of whether the runtime was a worker, a browser main thread, or
+ * Node.
+ *
+ * The only caller (`isWebBluetoothSupported`) happened to short-circuit on
+ * `typeof window !== "undefined"` first, so customers weren't visibly bitten
+ * — but the helper as a standalone primitive was useless. This test locks in
+ * the fix: reference `self` as a global instead of via top-level `this`.
+ */
+
+import { isMaybeWebWorkerContext } from "../api/bluetooth/web/isMaybeWebWorkerContext";
+
+describe("isMaybeWebWorkerContext", () => {
+  const originalSelf = (globalThis as any).self;
+
+  afterEach(() => {
+    if (originalSelf === undefined) {
+      delete (globalThis as any).self;
+    } else {
+      (globalThis as any).self = originalSelf;
+    }
+  });
+
+  it("returns true when `self` exists without a `document` (worker shape)", () => {
+    (globalThis as any).self = { postMessage: () => {} };
+    expect(isMaybeWebWorkerContext()).toBe(true);
+  });
+
+  it("returns false when `self` has a `document` (browser main thread shape)", () => {
+    (globalThis as any).self = { document: {} };
+    expect(isMaybeWebWorkerContext()).toBe(false);
+  });
+
+  it("returns false when `self` is not defined at all (Node / non-browser)", () => {
+    delete (globalThis as any).self;
+    expect(isMaybeWebWorkerContext()).toBe(false);
+  });
+});

--- a/src/api/bluetooth/web/isMaybeWebWorkerContext.ts
+++ b/src/api/bluetooth/web/isMaybeWebWorkerContext.ts
@@ -1,5 +1,16 @@
-const self: any = this;
-
+/**
+ * Returns true when the runtime looks like a Web Worker — `self` is defined
+ * as the global scope but there's no `document` (workers have `self`, only
+ * the browser main thread has `document` on top of that). Node/non-browser
+ * runtimes don't expose `self` at all, so this returns false there.
+ *
+ * Don't read top-level `this` to try to reach the global — in ES modules
+ * (what rollup emits) top-level `this` is `undefined`, and under CJS it's
+ * `module.exports`. Reference `self` as a global directly and let TS see
+ * it via `typeof self`.
+ */
 export const isMaybeWebWorkerContext = (): boolean => {
-  return self && self?.document === undefined;
+  return (
+    typeof self !== "undefined" && (self as any).document === undefined
+  );
 };


### PR DESCRIPTION
## Summary
`isMaybeWebWorkerContext()` was reading top-level `this` to try to reach the global scope:

```ts
const self: any = this;
export const isMaybeWebWorkerContext = () => self && self?.document === undefined;
```

In ES modules (what rollup emits) top-level `this` is spec'd as \`undefined\` — you've seen rollup's warning on every build:

\`\`\`
(!) "this" has been rewritten to "undefined"
src/api/bluetooth/web/isMaybeWebWorkerContext.ts
1: const self = this;
                ^
\`\`\`

So \`self\` was \`undefined\` and the expression short-circuited to a falsy value unconditionally. Under CJS (the jest test runtime) \`this\` is \`module.exports\`, which trivially satisfies \`!== undefined\` but also never has a \`document\`, so the helper returned true for every runtime. Either way, the worker-vs-browser decision was meaningless.

## Impact
Limited by accident: the only caller, \`isWebBluetoothSupported()\`, short-circuits on \`typeof window !== "undefined"\` first, so the bogus \`isMaybeWebWorkerContext()\` result never actually changed an answer. No visible customer breakage. But the primitive on its own was broken and the rollup warning was build noise.

## Fix
Reference \`self\` as a global via \`typeof self\` — no top-level \`this\` involved. No more rollup warning. The helper now returns what its name says:
- \`true\` for worker-shape globals (\`self\` exists, no \`document\`)
- \`false\` for browser main thread (\`self\` with \`document\`)
- \`false\` for Node / non-browser (no \`self\` at all)

## Test plan
- [x] \`npx jest src/__tests__/isMaybeWebWorkerContext.test.ts\` — 3/3 green (red against master)
- [x] \`npx jest\` full suite — 274 passed (was 271, +3 from this file)
- [x] \`npx rollup -c\` — no \"this has been rewritten\" warning

Suggest shipping as part of the next patch release (7.2.1).