### PR TITLE
chore: release v7.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v7.2.1
+
+- FIX: `isMaybeWebWorkerContext()` now actually detects worker context. The helper read top-level `this` (which is `undefined` in ES modules — rollup warned about the rewrite on every build), so it returned a falsy value unconditionally. Reference `self` as a global via `typeof self` instead. The only consumer (`isWebBluetoothSupported`) short-circuited on `typeof window` first, so no visible runtime impact — but the primitive on its own was broken and the build noise is gone.
+
 # v7.2.0
 
 - FIX: `selectDevice()` race — `observeNamespace(...)` subscribers (including `status()` and `osVersion()`) attached their RTDB listeners to the outgoing `FirebaseDevice` on every device switch. The v7 refactor had made the `onDeviceChange` subscriber async and awaited `disconnect()` before assigning `this.firebaseDevice = new FirebaseDevice(...)` — so subscribers delivered on the same emission read the stale device. Restores v6's synchronous swap; disconnect is now fire-and-forget with error logging.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neurosity/sdk",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neurosity/sdk",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "license": "MIT",
       "dependencies": {
         "@neurosity/ipk": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neurosity/sdk",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Neurosity SDK",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Cuts v7.2.1 for the `isMaybeWebWorkerContext` helper fix merged in #137 (commit `eb43263`).

- `package.json` + `package-lock.json` → 7.2.1
- `CHANGELOG.md` entry summarizing the fix

## Version choice
Patch bump (7.2.1) — strict semver, internal helper fix with no API surface change. Customer-visible: rollup no longer prints the `"this" has been rewritten to "undefined"` warning on every build.

## After merge
- Tag `v7.2.1` on master
- `npm publish --auth-type=web` (or granular access token path)