### PR TITLE
fix: re-export bundled firebase modules so consumers share class identity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neurosity/sdk",
-  "version": "7.1.0",
+  "version": "7.3.0",
   "description": "Neurosity SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/src/__tests__/firebase-reexports.test.ts
+++ b/src/__tests__/firebase-reexports.test.ts
@@ -1,0 +1,81 @@
+import * as sdk from "../index";
+
+// These tests pin the public surface added in fix/reexport-firebase-modules.
+// The whole point of those re-exports is that consumers can reach firebase
+// through the SDK and share class identity with the SDK's bundled copy.
+// If a future refactor accidentally drops a namespace — or worse, drops a
+// specific function from it — the consumer's `collection(db, ...)` call
+// falls back to their own `firebase/firestore` import and the brand check
+// fails again. Catch that here before it ships.
+describe("firebase modular re-exports", () => {
+  it("exposes the five firebase namespaces", () => {
+    expect(typeof sdk.app).toBe("object");
+    expect(typeof sdk.firestore).toBe("object");
+    expect(typeof sdk.database).toBe("object");
+    expect(typeof sdk.auth).toBe("object");
+    expect(typeof sdk.functions).toBe("object");
+  });
+
+  it.each([
+    "getFirestore",
+    "collection",
+    "doc",
+    "query",
+    "where",
+    "orderBy",
+    "limit",
+    "onSnapshot"
+  ])(
+    "sdk.firestore.%s should be a function (console-next reads use it)",
+    (name) => {
+      expect(typeof (sdk.firestore as Record<string, unknown>)[name]).toBe(
+        "function"
+      );
+    }
+  );
+
+  it.each(["getDatabase", "ref", "update", "get", "set", "onValue"])(
+    "sdk.database.%s should be a function (emulator power-on / device settings)",
+    (name) => {
+      expect(typeof (sdk.database as Record<string, unknown>)[name]).toBe(
+        "function"
+      );
+    }
+  );
+
+  it.each(["getAuth", "onAuthStateChanged"])(
+    "sdk.auth.%s should be a function",
+    (name) => {
+      expect(typeof (sdk.auth as Record<string, unknown>)[name]).toBe(
+        "function"
+      );
+    }
+  );
+
+  it.each(["getFunctions", "httpsCallable"])(
+    "sdk.functions.%s should be a function",
+    (name) => {
+      expect(typeof (sdk.functions as Record<string, unknown>)[name]).toBe(
+        "function"
+      );
+    }
+  );
+
+  it("the re-exported firebase is the SAME module the SDK uses internally", async () => {
+    // The whole reason for this PR. If `sdk.firestore` and the SDK's
+    // internal `import { getFirestore } from "firebase/firestore"` resolved
+    // to different module copies, the consumer fix would be a no-op — a
+    // consumer calling
+    // `sdk.firestore.collection(sdk.firestore.getFirestore(sdkApp), "x")`
+    // would still cross modules and trip the brand check.
+    //
+    // Verify they're the same reference.
+    const directFirestore = await import("firebase/firestore");
+    expect(sdk.firestore.getFirestore).toBe(directFirestore.getFirestore);
+    expect(sdk.firestore.collection).toBe(directFirestore.collection);
+
+    const directDatabase = await import("firebase/database");
+    expect(sdk.database.ref).toBe(directDatabase.ref);
+    expect(sdk.database.update).toBe(directDatabase.update);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,26 @@
 export * from "./Neurosity";
 export * from "./api/bluetooth";
 export * from "./types";
+
+// Re-export the firebase modular APIs that the SDK already bundles. Consumers
+// that build on top of the SDK should import firebase functions through these
+// namespaces rather than from `firebase/firestore` etc. directly — that way
+// the FirebaseApp returned by `neurosity.__getApp()` and the
+// `collection()` / `ref()` / `onAuthStateChanged()` calls operating on it
+// resolve to the SAME firebase module instance, and Firebase's runtime brand
+// checks pass.
+//
+// Why this matters: under pnpm, a consumer that also lists `firebase` as a
+// direct dependency gets a SEPARATE physical copy from the one bundled into
+// the SDK (peer-dep resolution variants live at their own
+// `node_modules/.pnpm/firebase@X.Y.Z_<hash>/` paths). Two physical copies →
+// two evaluations of the firebase classes → `collection(db, ...)` rejects a
+// Firestore whose internal classes came from the other copy with
+// "Expected first argument to collection() to be a CollectionReference,
+// a DocumentReference or FirebaseFirestore". The console-next Support Inbox
+// and the emulator power-on toggle hit this exact failure in 2026-05.
+export * as app from "firebase/app";
+export * as firestore from "firebase/firestore";
+export * as database from "firebase/database";
+export * as auth from "firebase/auth";
+export * as functions from "firebase/functions";


### PR DESCRIPTION
## Summary

The SDK already bundles firebase (rollup.config.js externalizes only `ws` and node built-ins). When a consumer also installs `firebase` as a direct dependency, pnpm gives the consumer a SEPARATE physical copy at `node_modules/.pnpm/firebase@X.Y.Z_<hash>/` — peer-dep variants live at distinct paths. Two physical copies → two evaluations of firebase's classes → Firebase's runtime brand checks fail the moment a consumer crosses the streams.

Concretely, this consumer pattern blows up:

```ts
import { collection } from "firebase/firestore";        // consumer's firebase
const db = getFirestore(neurosity.__getApp());          // SDK's firebase
collection(db, "conversations");
// FirebaseError: Expected first argument to collection() to be a
// CollectionReference, a DocumentReference or FirebaseFirestore
```

Real outages seen against `console-next` in 2026-05:

- Support Inbox stuck on "Loading…" even with admin role / passing Firestore rules.
- Emulator power-on RTDB write fails with `Maximum call stack size exceeded` / `t.split is not a function` depending on which internal code path the cross-module object trips first.

## Fix

Re-export firebase's modular APIs as namespaces from the SDK's main entry. Consumers can now write:

```ts
import { firestore } from "@neurosity/sdk";
const db = firestore.getFirestore(neurosity.__getApp());
firestore.collection(db, "conversations"); // ✓ same firebase copy, brand check passes
```

Namespaces added: `app`, `firestore`, `database`, `auth`, `functions`.

## Compatibility

Purely additive. No existing imports change. Existing consumers that don't touch the SDK's FirebaseApp instance directly will see no behavior change at all.

The proper follow-up in consumers (e.g. `neurosity-monorepo/apps/console-next/src/lib/firebase/app.ts`) is to swap `firebase/firestore` / `firebase/database` / `firebase/auth` imports for the SDK's namespaces wherever the call operates on `neurosity.__getApp()`.

## Test plan

- [x] `npm run build` — all 5 rollup targets emit cleanly, dist `index.d.ts` exports the 5 namespaces.
- [x] `npm test` — 104 tests pass, none broken.
- [ ] Smoke-test in `console-next` against this PR's published preview by re-pointing the package: confirm `/admin/support/conversations` populates for admin users and the emulator power-on toggle works on `/live`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)