### PR TITLE
feat: complete experiment API (v7.5.0) — rich fields, onExperimentMarkers, setEmulatorStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v7.5.0
+
+- FEAT: Complete the experiment API so the console can drop client-side RTDB entirely. (1) `Experiment` and `CreateExperimentOptions` now model the full session shape — `kind` (`training`/`recording`), `protocol`, `notes`, `durationMs`, `recordingState`, `recordingStartedAt`, `recordingId` — and `createUserExperiment` applies the training/recording defaults. (2) Added `onExperimentMarkers(experimentId)` — the live read counterpart to `addExperimentMarker`. (3) Added `setEmulatorStatus(deviceId, { state?, charging? })` for emulator/dev tooling that simulates device status. New exported types: `SessionKind`, `TrainingProtocol`, `RecordingState`, `EmulatorStatusPatch`.
+
 # v7.4.0
 
 - FEAT: Experiment write methods, so apps no longer touch RTDB directly for Studio data. Added `createUserExperiment(options)`, `updateUserExperiment(id, patch)`, `addExperimentMarker(id, marker)`, `saveExperimentTrial(id, trial)`, and `saveExperimentPrediction(id, prediction)` — siblings of the existing `onUserExperiments()` / `deleteUserExperiment()`. New exported types: `CreateExperimentOptions`, `ExperimentMarker`, `ExperimentTrial`, `ExperimentPrediction`. Full unit coverage of RTDB paths + payloads.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neurosity/sdk",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "description": "Neurosity SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/src/Neurosity.ts
+++ b/src/Neurosity.ts
@@ -46,7 +46,8 @@ import {
   CreateExperimentOptions,
   ExperimentMarker,
   ExperimentTrial,
-  ExperimentPrediction
+  ExperimentPrediction,
+  EmulatorStatusPatch
 } from "./types/experiment";
 import { TransferDeviceOptions } from "./utils/transferDevice";
 import { BluetoothClient, osHasBluetoothSupport } from "./api/bluetooth";
@@ -2019,5 +2020,49 @@ export class Neurosity {
     prediction: ExperimentPrediction
   ): Promise<string> {
     return this.cloudClient.saveExperimentPrediction(experimentId, prediction);
+  }
+
+  /**
+   * <StreamingModes wifi={true} />
+   *
+   * Observes the markers dropped during an experiment recording, sorted by
+   * timestamp. Each marker includes its `id`.
+   *
+   * ```typescript
+   * neurosity.onExperimentMarkers(experimentId).subscribe((markers) => {
+   *   console.log(markers);
+   * });
+   * ```
+   *
+   * @param experimentId The ID of the experiment
+   * @returns Observable of the experiment's markers
+   */
+  public onExperimentMarkers(
+    experimentId: string
+  ): Observable<ExperimentMarker[]> {
+    return this.cloudClient.onExperimentMarkers(experimentId);
+  }
+
+  /**
+   * <StreamingModes wifi={true} />
+   *
+   * Sets simulated status fields on an **emulator** device (e.g. toggling
+   * `state` or `charging`). Intended for emulator/dev tooling — on real
+   * hardware the device owns its status.
+   *
+   * ```typescript
+   * await neurosity.setEmulatorStatus(deviceId, { state: "online" });
+   * await neurosity.setEmulatorStatus(deviceId, { charging: true });
+   * ```
+   *
+   * @param deviceId The emulator device's ID
+   * @param patch Status fields to set (`state` and/or `charging`)
+   * @returns void
+   */
+  public setEmulatorStatus(
+    deviceId: string,
+    patch: EmulatorStatusPatch
+  ): Promise<void> {
+    return this.cloudClient.setEmulatorStatus(deviceId, patch);
   }
 }

--- a/src/__tests__/experiments.test.ts
+++ b/src/__tests__/experiments.test.ts
@@ -190,3 +190,84 @@ describe("saveExperimentPrediction", () => {
     });
   });
 });
+
+describe("createUserExperiment — session kinds", () => {
+  it("defaults a training experiment with protocol kinesis and no recording fields", async () => {
+    await makeUser("u1").createUserExperiment({ deviceId: "d1", kind: "training" });
+    const p = set.mock.calls[0][1];
+    expect(p.kind).toBe("training");
+    expect(p.protocol).toBe("kinesis");
+    expect(p.recordingState).toBeUndefined();
+    expect(p.durationMs).toBeUndefined();
+  });
+
+  it("creates a recording experiment with durationMs + recordingState idle, no protocol", async () => {
+    await makeUser("u1").createUserExperiment({ deviceId: "d1", kind: "recording" });
+    const p = set.mock.calls[0][1];
+    expect(p.kind).toBe("recording");
+    expect(p.recordingState).toBe("idle");
+    expect(p.durationMs).toBe(5 * 60 * 1000);
+    expect(p.protocol).toBeUndefined();
+  });
+
+  it("respects explicit durationMs + notes", async () => {
+    await makeUser("u1").createUserExperiment({
+      deviceId: "d1",
+      kind: "recording",
+      durationMs: 1000,
+      notes: "session A"
+    });
+    const p = set.mock.calls[0][1];
+    expect(p.durationMs).toBe(1000);
+    expect(p.notes).toBe("session A");
+  });
+
+  it("defaults kind to training when omitted", async () => {
+    await makeUser("u1").createUserExperiment({ deviceId: "d1" });
+    expect(set.mock.calls[0][1].kind).toBe("training");
+  });
+});
+
+describe("onExperimentMarkers", () => {
+  it("maps the markers map to a list sorted by timestamp, each with its id", async () => {
+    (database.onValue as jest.Mock).mockImplementation((_r: unknown, cb: any) => {
+      cb({
+        val: () => ({
+          b: { label: "lift", timestamp: 20 },
+          a: { label: "drop", timestamp: 10 }
+        })
+      });
+      return () => undefined;
+    });
+    const markers = await new Promise<any[]>((resolve) => {
+      const sub = makeUser("u1")
+        .onExperimentMarkers("e1")
+        .subscribe((m) => {
+          resolve(m);
+          setTimeout(() => sub.unsubscribe(), 0);
+        });
+    });
+    expect(ref).toHaveBeenCalledWith(expect.anything(), "experiments/e1/markers");
+    expect(markers.map((m) => m.id)).toEqual(["a", "b"]);
+    expect(markers[0]).toMatchObject({ id: "a", label: "drop", timestamp: 10 });
+  });
+});
+
+describe("setEmulatorStatus", () => {
+  it("rejects without a deviceId", async () => {
+    await expect(
+      makeUser("u1").setEmulatorStatus("", { state: "online" })
+    ).rejects.toMatch(/deviceId/);
+  });
+
+  it("updates devices/$id/status with the state patch", async () => {
+    await makeUser("u1").setEmulatorStatus("dev1", { state: "online" });
+    expect(ref).toHaveBeenCalledWith(expect.anything(), "devices/dev1/status");
+    expect(update).toHaveBeenCalledWith(expect.anything(), { state: "online" });
+  });
+
+  it("can toggle charging", async () => {
+    await makeUser("u1").setEmulatorStatus("dev1", { charging: true });
+    expect(update).toHaveBeenCalledWith(expect.anything(), { charging: true });
+  });
+});

--- a/src/api/firebase/FirebaseUser.ts
+++ b/src/api/firebase/FirebaseUser.ts
@@ -45,7 +45,9 @@ import {
   CreateExperimentOptions,
   ExperimentMarker,
   ExperimentTrial,
-  ExperimentPrediction
+  ExperimentPrediction,
+  EmulatorStatusPatch,
+  SessionKind
 } from "../../types/experiment";
 import { TransferDeviceOptions } from "../../utils/transferDevice";
 import {
@@ -696,15 +698,30 @@ export class FirebaseUser {
       return Promise.reject(`createUserExperiment: please provide a deviceId`);
     }
 
+    const kind: SessionKind = options.kind ?? "training";
+    const defaultName =
+      kind === "recording"
+        ? `Recording ${new Date().toLocaleString()}`
+        : `Experiment ${new Date().toLocaleString()}`;
+
     const database = getDatabase(this.app);
     const experimentRef = push(ref(database, "experiments"));
     await set(experimentRef, {
       userId,
       deviceId: options.deviceId,
-      name: options.name ?? `Experiment ${new Date().toLocaleString()}`,
+      name: options.name ?? defaultName,
+      notes: options.notes ?? "",
       labels: options.labels ?? [],
       totalTrials: 0,
-      timestamp: serverTimestamp()
+      timestamp: serverTimestamp(),
+      kind,
+      ...(kind === "training" && {
+        protocol: options.protocol ?? "kinesis"
+      }),
+      ...(kind === "recording" && {
+        durationMs: options.durationMs ?? 5 * 60 * 1000,
+        recordingState: "idle"
+      })
     });
     return experimentRef.key as string;
   }
@@ -776,5 +793,36 @@ export class FirebaseUser {
       timestamp: prediction.timestamp ?? serverTimestamp()
     });
     return predictionRef.key as string;
+  }
+
+  onExperimentMarkers(experimentId: string): Observable<ExperimentMarker[]> {
+    if (!experimentId) {
+      return EMPTY;
+    }
+    const database = getDatabase(this.app);
+    const markersRef = ref(database, `experiments/${experimentId}/markers`);
+    return fromEventPattern(
+      (handler) =>
+        onValue(markersRef, (snapshot: DataSnapshot) => handler(snapshot)),
+      () => off(markersRef)
+    ).pipe(
+      map((snapshot: DataSnapshot) => snapshot.val()),
+      map((markersMap): ExperimentMarker[] =>
+        Object.entries(markersMap ?? {})
+          .map(([id, value]: any) => ({ id, ...value }) as ExperimentMarker)
+          .sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0))
+      )
+    );
+  }
+
+  async setEmulatorStatus(
+    deviceId: string,
+    patch: EmulatorStatusPatch
+  ): Promise<void> {
+    if (!deviceId) {
+      return Promise.reject(`setEmulatorStatus: please provide a deviceId`);
+    }
+    const database = getDatabase(this.app);
+    await update(ref(database, `devices/${deviceId}/status`), patch);
   }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -26,7 +26,8 @@ import {
   CreateExperimentOptions,
   ExperimentMarker,
   ExperimentTrial,
-  ExperimentPrediction
+  ExperimentPrediction,
+  EmulatorStatusPatch
 } from "../types/experiment";
 import { TransferDeviceOptions } from "../utils/transferDevice";
 import {
@@ -461,6 +462,19 @@ export class CloudClient implements Client {
     prediction: ExperimentPrediction
   ): Promise<string> {
     return this.firebaseUser.saveExperimentPrediction(experimentId, prediction);
+  }
+
+  public onExperimentMarkers(
+    experimentId: string
+  ): Observable<ExperimentMarker[]> {
+    return this.firebaseUser.onExperimentMarkers(experimentId);
+  }
+
+  public setEmulatorStatus(
+    deviceId: string,
+    patch: EmulatorStatusPatch
+  ): Promise<void> {
+    return this.firebaseUser.setEmulatorStatus(deviceId, patch);
   }
 
   public get skills(): SkillsClient {

--- a/src/types/experiment.ts
+++ b/src/types/experiment.ts
@@ -1,3 +1,12 @@
+/**
+ * Session kind. `training` covers classifier-training protocols (kinesis,
+ * SSVEP, …); `recording` is a simple timed raw-EEG capture. Experiments
+ * created before dual-mode are treated as `training`.
+ */
+export type SessionKind = "training" | "recording";
+export type TrainingProtocol = "kinesis" | "ssvep";
+export type RecordingState = "idle" | "running" | "complete" | "error";
+
 export type Experiment = {
   deviceId: string;
   id: string;
@@ -6,6 +15,20 @@ export type Experiment = {
   timestamp: number;
   totalTrials: number;
   userId: string;
+  /** Free-form notes. */
+  notes?: string;
+  /** Session kind; defaults to `training` for pre-dual-mode docs. */
+  kind?: SessionKind;
+  /** Training-only: which classifier protocol. */
+  protocol?: TrainingProtocol;
+  /** Recording-only: planned duration in ms. */
+  durationMs?: number;
+  /** Recording-only: lifecycle state. */
+  recordingState?: RecordingState;
+  /** Recording-only: epoch ms the recording actually started. */
+  recordingStartedAt?: number;
+  /** Recording-only: resulting memory/recording id once complete. */
+  recordingId?: string;
 };
 
 /**
@@ -19,6 +42,25 @@ export type CreateExperimentOptions = {
   name?: string;
   /** Initial classifier labels (e.g. `["leftHandPinch", "drop"]`). */
   labels?: string[];
+  /** Session kind. Defaults to `training`. */
+  kind?: SessionKind;
+  /** Training-only classifier protocol. Defaults to `kinesis`. */
+  protocol?: TrainingProtocol;
+  /** Recording-only planned duration in ms. Defaults to 5 minutes. */
+  durationMs?: number;
+  /** Free-form notes. */
+  notes?: string;
+};
+
+/**
+ * Status fields that can be simulated on an emulator device via
+ * {@link Neurosity.setEmulatorStatus}.
+ */
+export type EmulatorStatusPatch = {
+  /** Simulated connection/run state (e.g. `"online"`, `"offline"`). */
+  state?: string;
+  /** Simulated charging flag. */
+  charging?: boolean;
 };
 
 /**
@@ -26,6 +68,8 @@ export type CreateExperimentOptions = {
  * `experiments/{experimentId}/markers`.
  */
 export type ExperimentMarker = {
+  /** The marker's id (present when read back via `onExperimentMarkers`). */
+  id?: string;
   /** The label/event this marker represents. */
   label: string;
   /** Epoch milliseconds when the marker occurred. */


### PR DESCRIPTION
## Why
7.4.0 added experiment *write* methods, but doing the console swap surfaced that they were under-scoped: the console models `training` vs `recording` sessions (`kind`, `protocol`, `notes`, `recordingState`…), reads markers live, and writes emulator status. This completes the API so the console can drop **all** client RTDB.

## What
- **Rich session shape** on `Experiment` + `CreateExperimentOptions`: `kind`, `protocol`, `notes`, `durationMs`, `recordingState`, `recordingStartedAt`, `recordingId`. `createUserExperiment` applies training (`protocol=kinesis`) / recording (`durationMs`, `recordingState=idle`) defaults; `updateUserExperiment`'s patch type widens automatically.
- **`onExperimentMarkers(experimentId)`** — live read counterpart to the 7.4.0 `addExperimentMarker`.
- **`setEmulatorStatus(deviceId, { state?, charging? })`** — removes the last raw RTDB write in the console (emulator power/charging sim).
- New exported types: `SessionKind`, `TrainingProtocol`, `RecordingState`, `EmulatorStatusPatch`.

## Verification
- `jest`: **39 suites, 326 passed, 0 failures** (22 in experiments.test.ts, 8 new).
- `tsc --noEmit`: **0 errors**.
- TSDoc + `@example` on the new public methods.

## Next
Publish **7.5.0** → bump console-next → swap Studio + emulator controls off RTDB (zero `rtdb()` left in the console).

🤖 Generated with [Claude Code](https://claude.com/claude-code)