### PR TITLE
fix(emulator): derive sleepMode from charging in setEmulatorStatus (7.5.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neurosity/sdk",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "description": "Neurosity SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/src/__tests__/experiments.test.ts
+++ b/src/__tests__/experiments.test.ts
@@ -266,8 +266,28 @@ describe("setEmulatorStatus", () => {
     expect(update).toHaveBeenCalledWith(expect.anything(), { state: "online" });
   });
 
-  it("can toggle charging", async () => {
+  it("derives sleepMode when charging is turned on", async () => {
     await makeUser("u1").setEmulatorStatus("dev1", { charging: true });
-    expect(update).toHaveBeenCalledWith(expect.anything(), { charging: true });
+    expect(update).toHaveBeenCalledWith(expect.anything(), {
+      charging: true,
+      sleepMode: true,
+      sleepModeReason: "charging"
+    });
+  });
+
+  it("clears sleepMode/sleepModeReason when charging is turned off", async () => {
+    await makeUser("u1").setEmulatorStatus("dev1", { charging: false });
+    expect(update).toHaveBeenCalledWith(expect.anything(), {
+      charging: false,
+      sleepMode: false,
+      sleepModeReason: null
+    });
+  });
+
+  it("does not derive sleepMode for a state-only patch", async () => {
+    await makeUser("u1").setEmulatorStatus("dev1", { state: "offline" });
+    expect(update).toHaveBeenCalledWith(expect.anything(), {
+      state: "offline"
+    });
   });
 });

--- a/src/api/firebase/FirebaseUser.ts
+++ b/src/api/firebase/FirebaseUser.ts
@@ -823,6 +823,16 @@ export class FirebaseUser {
       return Promise.reject(`setEmulatorStatus: please provide a deviceId`);
     }
     const database = getDatabase(this.app);
-    await update(ref(database, `devices/${deviceId}/status`), patch);
+    // Mirror the device-emulator's own charging derivation: when `charging`
+    // changes, `sleepMode`/`sleepModeReason` are derived from it so the status
+    // we write matches exactly what the emulator process would write itself.
+    // Without this, the charging flag would land but `sleepMode` would go
+    // stale.
+    const status: EmulatorStatusPatch = { ...patch };
+    if (typeof patch.charging === "boolean") {
+      status.sleepMode = patch.charging;
+      status.sleepModeReason = patch.charging ? "charging" : null;
+    }
+    await update(ref(database, `devices/${deviceId}/status`), status);
   }
 }

--- a/src/types/experiment.ts
+++ b/src/types/experiment.ts
@@ -61,6 +61,14 @@ export type EmulatorStatusPatch = {
   state?: string;
   /** Simulated charging flag. */
   charging?: boolean;
+  /**
+   * Derived from `charging` by `setEmulatorStatus` — not set directly by
+   * callers. Mirrors the device-emulator's own `getChargingStatus` so the
+   * written status stays consistent.
+   */
+  sleepMode?: boolean;
+  /** Derived alongside `sleepMode`; `"charging"` while charging, else `null`. */
+  sleepModeReason?: string | null;
 };
 
 /**


### PR DESCRIPTION
## Problem

`setEmulatorStatus` wrote the caller's patch verbatim. So toggling the emulator's **charging** flag set `charging` but left `sleepMode` / `sleepModeReason` stale — the written status didn't match what the emulator itself produces.

The device-emulator derives these from charging in its own `getChargingStatus`:
```ts
{ charging, sleepMode: charging, sleepModeReason: charging ? "charging" : null }
```

A client-side status write (the console's emulator control panel) bypasses the emulator's `status/update` action handler and writes `devices/$id/status` directly, so it has to reproduce that derivation or the status desyncs. The old console did this by hand; the SDK method didn't.

## Fix

`setEmulatorStatus` now derives `sleepMode`/`sleepModeReason` whenever the patch includes a boolean `charging`, mirroring the emulator exactly. **State-only** patches are unchanged (the emulator sets no `sleepMode` on state transitions).

## Tests
- charging → on derives `sleepMode: true, sleepModeReason: "charging"`
- charging → off clears to `sleepMode: false, sleepModeReason: null`
- state-only patch derives nothing

Full suite: 328 passed / 12 skipped / 0 failed · tsc clean.

> Release (`npm publish` → 7.5.1) is the maintainer's step — not done here. After publish, bump `apps/console-next` to `^7.5.1` in PR #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)